### PR TITLE
fix(upload): adding extraargs

### DIFF
--- a/pibooth_s3_upload.py
+++ b/pibooth_s3_upload.py
@@ -64,7 +64,7 @@ def state_processing_exit(app, cfg):
         upload_path = s3_prefix + os.path.basename(app.previous_picture_file)
 
         try:
-            response = app.s3_client.upload_file(app.previous_picture_file, s3_bucket_name, upload_path)
+            response = app.s3_client.upload_file(app.previous_picture_file, s3_bucket_name, upload_path, ExtraArgs={"ContentType": "image/jpeg"}))
             LOGGER.info("File uploaded to S3: " + upload_path)
         except ClientError as e:
             LOGGER.error(e)


### PR DESCRIPTION
ExtraArgs to add a content-type of image/jpg, in case someone is using a public bucket and is sharing the URL via the qrcode plugin.   This stops the image from being downloaded, and instead displayed in the browser.